### PR TITLE
cloud-init additions, cfn-init refactor, chef-solo refactor

### DIFF
--- a/cfer-provisioning.gemspec
+++ b/cfer-provisioning.gemspec
@@ -14,14 +14,6 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/seanedwards/cfer-provisioning"
   spec.license       = "MIT"
 
-  # Prevent pushing this gem to RubyGems.org by setting 'allowed_push_host', or
-  # delete this section to allow pushing this gem to any host.
-  if spec.respond_to?(:metadata)
-    spec.metadata['allowed_push_host'] = "TODO: Set to 'http://mygemserver.com'"
-  else
-    raise "RubyGems 2.0 or newer is required to protect against public gem pushes."
-  end
-
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }

--- a/cfer-provisioning.gemspec
+++ b/cfer-provisioning.gemspec
@@ -33,4 +33,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "serverspec"
 
   spec.add_runtime_dependency 'cfer'
+  spec.add_runtime_dependency 'erubis', '~> 2.7.0'
 end

--- a/lib/cfer/cfizer.rb
+++ b/lib/cfer/cfizer.rb
@@ -1,0 +1,47 @@
+module Cfer
+  DEFAULT_CAPTURE_REGEXP = /C\{(?<directive>.*?)\}/
+
+  class Cfizer
+    begin
+      include Cfer::Core::Functions
+    rescue NameError => _
+      # we need to fall back to the old Cfer setup
+      include Cfer::Core
+      include Cfer::Cfn
+    end
+
+    def cfize(directive)
+      instance_eval directive
+    end
+  end
+
+  def self.cfize(text, capture_regexp: nil)
+    raise "'text' must be a string." unless text.is_a?(String)
+
+    capture_regexp ||= DEFAULT_CAPTURE_REGEXP
+
+    raise "'capture_regexp' must be a Regexp." unless capture_regexp.is_a?(Regexp)
+    raise "'capture_regexp' must include a 'contents' named 'directive'." \
+      unless capture_regexp.named_captures.key?('directive')
+
+    working = []
+    until(working[-2] == "" && working[-1] == "") do
+      if (working.size == 0)
+        working = text.partition(capture_regexp)
+      else
+        working[-1] = working[-1].partition(capture_regexp)
+        working = working.flatten
+      end
+    end
+
+    cfizer = Cfizer.new
+    Cfizer::Fn.join("", working.map do |token|
+      match = capture_regexp.match(token)
+      if (match.nil?)
+        token
+      else
+        cfizer.cfize(match['directive'])
+      end
+    end.reject { |t| t == ""})
+  end
+end

--- a/lib/cfer/provisioning.rb
+++ b/lib/cfer/provisioning.rb
@@ -1,4 +1,5 @@
 require "cfer/provisioning/version"
+require "cfer/cfizer"
 require 'cfer'
 
 require 'base64'
@@ -9,6 +10,9 @@ module Cfer
   end
 end
 
+require 'cfer/provisioning/extensions'
+
+require 'cfer/provisioning/cloud-init'
 require 'cfer/provisioning/cfn-bootstrap'
 require 'cfer/provisioning/chef'
 

--- a/lib/cfer/provisioning/cfn-bootstrap.bash.erb
+++ b/lib/cfer/provisioning/cfn-bootstrap.bash.erb
@@ -1,0 +1,30 @@
+#! /bin/bash -xe
+
+function error_exit
+{
+<% unless @options[:signal].nil? %>
+  /usr/local/bin/cfn-signal -s 'false' \
+    --resource '<%= @options[:signal] %>' \
+    --stack 'C{AWS.stack_name}' \
+    --region 'C{AWS.region}'
+<% end %>
+
+  exit 1
+}
+
+/usr/local/bin/cfn-init \
+  --resource '<%= @resource_name %>' \
+  --stack 'C{AWS.stack_name}' \
+  --region 'C{AWS.region}' \
+  --configsets '<%= @options[:cfn_init_config_set].join(",") %>' || error_exit 'cfn-init failed to start'
+
+<% unless @options[:cfn_hup_config_set].nil? -%>
+  /usr/local/bin/cfn-hup || error_exit 'cfn-hup failed to start'
+<% end -%>
+
+<% unless @options[:signal].nil? -%>
+  /usr/local/bin/cfn-signal -s 'true' \
+    --resource '<%= @options[:signal] %>' \
+    --stack 'C{AWS.stack_name}' \
+    --region 'C{AWS.region}'
+<% end -%>

--- a/lib/cfer/provisioning/cfn-bootstrap.rb
+++ b/lib/cfer/provisioning/cfn-bootstrap.rb
@@ -1,7 +1,7 @@
 require 'erubis'
 
 module Cfer::Provisioning
-  DEFAULT_HUP_INTERVAL_IN_MINUTES = 1
+  DEFAULT_HUP_INTERVAL_IN_MINUTES = 5
 
   def cfn_metadata
     self[:Metadata] ||= {}
@@ -103,7 +103,7 @@ module Cfer::Provisioning
         [main]
         stack=C{AWS.stack_name}
         region=C{AWS.region}
-        interval=#{DEFAULT_HUP_INTERVAL_IN_MINUTES}
+        interval=#{options[:hup_interval] || DEFAULT_HUP_INTERVAL_IN_MINUTES}
       FILE
       file '/etc/cfn/cfn-hup.conf', content: Cfer.cfize(hup_conf_content),
         mode: '000400', owner: 'root', group: 'root'

--- a/lib/cfer/provisioning/chef.rb
+++ b/lib/cfer/provisioning/chef.rb
@@ -26,6 +26,10 @@ module Cfer::Provisioning
         export LANG=en_US.UTF-8
         export RUBYOPTS="-E utf-8"
 
+        set -e
+        [ -f /opt/chef/embedded/bin/berks ] || /opt/chef/embedded/bin/gem install berkshelf
+        set +e
+
         # Berkshelf seems a bit unreliable, so retry these commands a couple times.
         if [ -e Berksfile.lock ]
         then

--- a/lib/cfer/provisioning/client.rb.erb
+++ b/lib/cfer/provisioning/client.rb.erb
@@ -1,0 +1,22 @@
+chef_server_url                           '<%= options[:chef_server_url] %>'
+validation_client_name                    '<%= options[:validation_client_name] %>'
+log_level                                 <%= (options[:log_level] || :info).inspect %>
+log_location                              '<%= options[:log_path] %>'
+json_attribs                              '<%= options[:json_path] %>'
+cookbook_path                             '<%= options[:cookbook_path] %>'
+
+<%- case options[:node_name]
+    when nil -%>
+<%- when :hostname -%>
+  node_name                               `hostname`.strip
+<%- else -%>
+  node_name '<%= options[:node_name] %>'
+<%- end %>
+
+<%- unless options[:environment].nil? -%>
+  environment                             '<%= options[:environment] %>'
+<%- end -%>
+
+<%- unless options[:validation_key].nil? -%>
+  validation_key                          '<%= options[:validation_key] %>'
+<%- end -%>

--- a/lib/cfer/provisioning/cloud-init.rb
+++ b/lib/cfer/provisioning/cloud-init.rb
@@ -1,0 +1,75 @@
+require 'yaml'
+
+module Cfer::Provisioning
+  def cloud_init
+    unless self.key?(:CloudInit)
+      self[:CloudInit] = {
+        bootcmd: [],
+        runcmd: [],
+        packages: [],
+        ssh_authorized_keys: [],
+        write_files: [
+          {
+            path: '/etc/cfn-resource-name',
+            permissions: '0444',
+            content: @name.to_s
+          },
+          {
+            path: '/etc/cfn-stack-name',
+            permissions: '0444',
+            content: 'C{AWS.stack_name}'
+          },
+          {
+            path: '/etc/cfn-region',
+            permissions: '0444',
+            content: 'C{AWS.region}'
+          }
+        ],
+        output: {}
+      }
+    end
+
+    self[:CloudInit]
+  end
+
+  def cloud_init_bootcmds
+    cloud_init[:bootcmd]
+  end
+
+  def cloud_init_runcmds
+    cloud_init[:runcmd]
+  end
+
+  def cloud_init_outputs
+    cloud_init[:output]
+  end
+
+  def cloud_init_packages
+    cloud_init[:packages]
+  end
+
+  def cloud_init_write_files
+    cloud_init[:write_files]
+  end
+
+  def cloud_init_ssh_authorized_keys
+    cloud_init[:ssh_authorized_keys]
+  end
+
+  def cloud_init_finalize!
+    cloud_init_outputs[:all] ||= "| tee -a /var/log/cloud-init-output.log"
+
+    user_data Cfer::Core::Fn.base64( cloud_init_to_user_data(self[:CloudInit]) )
+    self.delete :CloudInit
+  end
+
+  private
+  def cloud_init_to_user_data(cloud_init)
+
+    Cfer.cfize([
+      '#cloud-config',
+      YAML.dump(cloud_init.to_hash_recursive.deep_stringify_keys).gsub(/^---$/, "")
+    ].join("\n"))
+  end
+
+end

--- a/lib/cfer/provisioning/extensions.rb
+++ b/lib/cfer/provisioning/extensions.rb
@@ -1,0 +1,33 @@
+class Hash
+  def to_hash_recursive
+    result = self.to_hash
+
+    result.each do |key, value|
+      case value
+      when Hash
+        result[key] = value.to_hash_recursive
+      when Array
+        result[key] = value.to_hash_recursive
+      end
+    end
+
+    result
+  end
+end
+
+class Array
+  def to_hash_recursive
+    result = self
+
+    result.each_with_index do |value,i|
+      case value
+      when Hash
+        result[i] = value.to_hash_recursive
+      when Array
+        result[i] = value.to_hash_recursive
+      end
+    end
+
+    result
+  end
+end

--- a/lib/cfer/provisioning/version.rb
+++ b/lib/cfer/provisioning/version.rb
@@ -1,5 +1,5 @@
 module Cfer
   module Provisioning
-    VERSION = "0.1.0"
+    VERSION = "0.2.0"
   end
 end


### PR DESCRIPTION
This is a bigger PR than I necessarily would've wanted, but things got out of hand.

The big upshot is that cfer-provisioning now uses `cloud-init` as its primary way of Doing Stuff; cfn-init is triggered from cloud-init. The chef-solo stuff is cleaned up, in preparation for adding chef-client support as well. A nice side effect of moving to cloud-init is that _you can't log into the instance until cfn-init has finished running_; this makes knowing "hey, has Chef finished?" really easy.

I also added a `Cfer::cfize` method; I needed it so as to not go literally insane. It allows you to produce arbitrary strings and evals the directives within `C{}` in order to create `Fn::Join` JSON blobs without hating yourself. This may make sense to move into Cfer core.

There _is_ also a version bump in this package, because it is significantly different.

@seanedwards - some sort of hook would be nice so that a cfer-provisioning can trigger `cloud_init_finalize!` automatically (which YAMLizes the cloud-init stuff and dumps it out as userdata).

An example of using (most of) the functionality of cloud-init on the fly:

```
require 'cfer/provisioning'

resource :TestInstance, 'AWS::EC2::Instance' do
  source_dest_check true
  disable_api_termination false

  key_name 'MyKey'

  instance_type 't2.nano'
  image_id 'ami-b9ff39d9'

  network_interfaces \
    [
      {
        AssociatePublicIpAddress: true,
        DeviceIndex: 0,
        GroupSet: [ 'sg-aabbccdd' ],
        SubnetId: 'subnet-aabbccdd'
      }
    ]

  cloud_init_packages << 'tcsh'
  cloud_init_packages << 'htop'
  cloud_init_packages << 'zsh'

  cloud_init_bootcmds << 'echo 1 > /BOOTCMD'
  cloud_init_bootcmds << 'echo 1 > /BOOTCMD2'

  cloud_init_write_files << {
    path: '/WRITE_FILE',
    content: <<-EOF.strip_heredoc
      hello
      i am
      a walrus
    EOF
  }
  cloud_init_write_files << {
    path: '/WRITE_FILE2',
    content: <<-EOF.strip_heredoc
      i am
      not
      a walrus

      i am
      a goat
    EOF
  }

  cfn_init_setup \
    cfn_init_config_set: [ :cfn_hup, :run_chef_solo ],
    cfn_hup_config_set: [ :cfn_hup, :run_chef_solo ]

  berksfile = <<-BERKS
    source 'https://supermarket.chef.io'

    cookbook 'nginx', '~> 2.7.6'
  BERKS

  chef_solo \
    berksfile: berksfile,
    run_list: [ 'nginx::default' ],
    json: {
      foo: 'bar',
      baz: 5
    }

  cloud_init_finalize!

  tag :'Name', 'test-cf-machine'
end

output :Ip, Fn.get_att(:TestInstance, :PublicIp)
```
